### PR TITLE
allow to override cellRenderer per column

### DIFF
--- a/Ardagryd.js
+++ b/Ardagryd.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import _ from 'underscore'
 import { Input, Glyphicon, Button, FormControl, Table, Pagination } from 'react-bootstrap'
+import { elementType } from 'react-prop-types';
 import merge from 'deepmerge'
 
 const ASCENDING = "asc";
@@ -178,6 +179,10 @@ const GridBody=(props)=>{
         var rows = props.objects.map((curr) => {
             let current = curr;
             var cells = props.columnKeys.map((key) => {
+                let configForColumn = props.columns[key];
+                if(configForColumn && configForColumn.cellRendererBase){
+                    CellRenderer = configForColumn.cellRendererBase;
+                }
                 return (
                     <Cell key={key} columnName={key}>
                         <CellRenderer config={props.config} value={current[key]} columns={props.columns} columnName={key} object={current}>
@@ -499,6 +504,7 @@ Ardagryd.propTypes = {
       order: React.PropTypes.number,
       hideTools: React.PropTypes.bool,
       sortable: React.PropTypes.bool,
+      cellRendererBase: elementType,
       filter: React.PropTypes.string
     })).isRequired,
     dispatch: React.PropTypes.func.isRequired

--- a/Ardagryd.js
+++ b/Ardagryd.js
@@ -180,8 +180,8 @@ const GridBody=(props)=>{
             let current = curr;
             var cells = props.columnKeys.map((key) => {
                 let configForColumn = props.columns[key];
-                if(configForColumn && configForColumn.cellRendererBase){
-                    CellRenderer = configForColumn.cellRendererBase;
+                if(configForColumn && configForColumn.cellRenderer){
+                    CellRenderer = configForColumn.cellRenderer;
                 }
                 return (
                     <Cell key={key} columnName={key}>
@@ -504,7 +504,7 @@ Ardagryd.propTypes = {
       order: React.PropTypes.number,
       hideTools: React.PropTypes.bool,
       sortable: React.PropTypes.bool,
-      cellRendererBase: elementType,
+      cellRenderer: elementType,
       filter: React.PropTypes.string
     })).isRequired,
     dispatch: React.PropTypes.func.isRequired

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "deepmerge": "^0.2.10",
     "react-bootstrap": "^0.29.4",
+    "react-prop-types": "^0.3.2",
     "react-select": "^1.0.0-beta13",
     "underscore": "^1.8.3"
   },

--- a/test/GridTest.js
+++ b/test/GridTest.js
@@ -312,5 +312,22 @@ describe('Grid render tests', function(){
     should(tbodyDOM.childNodes[0].childNodes.length).be.exactly(1);
 
   });
+  
+  it('Should be possible to override the cell renderer per column', function (){
 
+    let grid = TestUtils.renderIntoDocument(
+      <Grid objects={data} columns={{
+        name: {
+          order: 0,
+          cellRendererBase: ({object: {name, email}})=><a href={`mailto:${email}`}>{name}</a>
+        }
+        }} config={{}}/>
+    );
+
+    let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
+    let tbodyDOM = ReactDOM.findDOMNode(tbody);
+
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly('<a href="mailto:Emilian20@yahoo.com">Nike Floder</a>');
+  });
+  
 });

--- a/test/GridTest.js
+++ b/test/GridTest.js
@@ -319,7 +319,7 @@ describe('Grid render tests', function(){
       <Grid objects={data} columns={{
         name: {
           order: 0,
-          cellRendererBase: ({object: {name, email}})=><a href={`mailto:${email}`}>{name}</a>
+          cellRenderer: ({object: {name, email}})=><a href={`mailto:${email}`}>{name}</a>
         }
         }} config={{}}/>
     );


### PR DESCRIPTION
I wonder if we should just call the prop `cellRenderer` though.
Also, this adds the `react-prop-types` dependency, which I'm not sure we want to.