### PR TITLE
Render values without span elements

### DIFF
--- a/Ardagryd.js
+++ b/Ardagryd.js
@@ -184,8 +184,12 @@ const GridBody=(props)=>{
                     displayValueGetter = configForColumn.displayValueGetter;
                 }
                 const args = {columns:props.columns, columnName:key, config:props.config, value:current[key], object:current};
-                const value = displayValueGetter(args);
-
+                let value;
+                if (displayValueGetter.prototype.isReactComponent){
+                    value = React.createElement(displayValueGetter, args);
+                }else{
+                    value = displayValueGetter(args);
+                }
                 if (value == null){
                     return <Cell key={key} columnName={key}/>;
                 }

--- a/test/GridTest.js
+++ b/test/GridTest.js
@@ -399,5 +399,43 @@ describe('Grid render tests', function(){
 
     should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("<ul><li><span>Dude</span></li><li><span>Johnny</span></li></ul>");
   });
+  
+  it('Can dynamically add an array-typed column', function (){
+
+    let grid = TestUtils.renderIntoDocument(
+      <Grid objects={[{name: "John"}]} columns={{
+        nickNames: {
+          displayValueGetter: ({object})=>["Dude", "Johnny"],
+          order: 0
+        },
+        name: {
+          id: true,
+          show: false
+        }
+        }} config={{}}/>
+    );
+
+    let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
+    let tbodyDOM = ReactDOM.findDOMNode(tbody);
+
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("<ul><li><span>Dude</span></li><li><span>Johnny</span></li></ul>");
+  });
+  
+  it('Can override the displayValueGetter for an array-typed column', function (){
+
+    let grid = TestUtils.renderIntoDocument(
+      <Grid objects={[{nickNames: ["Dude", "Johnny"]}]} columns={{
+        nickNames: {
+          order: 0,
+          displayValueGetter:  ({value})=>value.join(" or ")
+        }
+        }} config={{}}/>
+    );
+
+    let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
+    let tbodyDOM = ReactDOM.findDOMNode(tbody);
+
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("Dude or Johnny");
+  });
 
 });

--- a/test/GridTest.js
+++ b/test/GridTest.js
@@ -319,7 +319,7 @@ describe('Grid render tests', function(){
       <Grid objects={data} columns={{
         name: {
           order: 0,
-          displayValueGetter: ({object})=><span>John Doe</span>
+          displayValueGetter: ({object})=>"John Doe"
         }
         }} config={{}}/>
     );
@@ -327,7 +327,7 @@ describe('Grid render tests', function(){
     let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
     let tbodyDOM = ReactDOM.findDOMNode(tbody);
 
-    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("<span>John Doe</span>");
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("John Doe");
   });
   
   it('Should be possible to override global displayValueGetter', function (){
@@ -338,14 +338,14 @@ describe('Grid render tests', function(){
           order: 0
         }
         }} config={{
-          displayValueGetter: ({object})=><span>This is the name</span>
+          displayValueGetter: ({object})=>"This is the name"
         }}/>
     );
 
     let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
     let tbodyDOM = ReactDOM.findDOMNode(tbody);
 
-    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("<span>This is the name</span>");
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("This is the name");
   });
   
   it('Should be possible to override the global displayValueGetter with a per-column configuration', function (){
@@ -354,17 +354,35 @@ describe('Grid render tests', function(){
       <Grid objects={data} columns={{
         name: {
           order: 0,
-          displayValueGetter: ({object})=><span>Robert Paulson</span>
+          displayValueGetter: ({object})=>"Robert Paulson"
         }
         }} config={{
-          displayValueGetter: ({object})=><span>This is the name</span>
+          displayValueGetter: ({object})=>"This is the name"
         }}/>
     );
 
     let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
     let tbodyDOM = ReactDOM.findDOMNode(tbody);
 
-    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("<span>Robert Paulson</span>");
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly("Robert Paulson");
+  });
+  
+  //TODO this is deprecated!
+  it('Should be possible to return an element from the displayValueGetter', function (){
+
+    let grid = TestUtils.renderIntoDocument(
+      <Grid objects={data} columns={{
+        name: {
+          order: 0,
+          displayValueGetter: ({object})=><span>"John Doe"</span>
+        }
+        }} config={{}}/>
+    );
+
+    let tbody = TestUtils.scryRenderedDOMComponentsWithTag(grid, "tbody")[0];
+    let tbodyDOM = ReactDOM.findDOMNode(tbody);
+
+    should(tbodyDOM.childNodes[0].childNodes[0].innerHTML).be.exactly('<span>"John Doe"</span>');
   });
   
   it('Should render an array value', function (){


### PR DESCRIPTION
Modify the `displayValueGetter` construct to be able to return a scalar value (e.g. a string) and render that directly into the `td`.
Before merging this, we should be sure about the `displayValueGetter` function's signature. Passing in all the props has the advantage that we can also use a component class as the value.