### PR TITLE
throw an error if an invalid value (e.g. a number < 1) is passed as `config.paging`

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -14,7 +14,7 @@ export class App extends React.Component {
     let externalData = {getThis: "External data"};
 
 
-    var config = {showToolbar: true, paging: 10};
+    var config = {showToolbar: true, paging: 0};
     var columns = {
 
       edit: {

--- a/lib/Ardagryd.js
+++ b/lib/Ardagryd.js
@@ -182,7 +182,7 @@ const Ardagryd = (props)=>{
     const usePaging = paging !== undefined && paging !== false;
     if (usePaging){
         if (paging < 1){
-            throw new Error("Invalid value for config.paging: " + paging);
+            throw new Error(`Invalid value for config.paging: ${paging}`);
         }
         pagedObjects = objects.slice(props.skip, props.skip+paging);
     } else {

--- a/lib/Ardagryd.js
+++ b/lib/Ardagryd.js
@@ -181,6 +181,9 @@ const Ardagryd = (props)=>{
     const paging = config.paging;
     const usePaging = paging !== undefined && paging !== false;
     if (usePaging){
+        if (paging < 1){
+            throw new Error("Invalid value for config.paging: " + paging);
+        }
         pagedObjects = objects.slice(props.skip, props.skip+paging);
     } else {
         pagedObjects = objects;

--- a/test/GridTest.js
+++ b/test/GridTest.js
@@ -491,4 +491,10 @@ describe('Grid render tests', function(){
     expect(grid.find("tbody").children().length).be.equal(5);
   });
 
+  it('Should throw an error when specifying a number < 1 for paging', ()=>{
+    expect(function(){
+      render(<Grid objects={data} config={{paging:0}} />)
+    }).to.throw(/Invalid value for config.paging/);
+  });
+
 });


### PR DESCRIPTION
See #57 
I'm not entirely convinced that this is the best solution. Maybe we should rather do this with a custom proptype matcher. But at least the misconfiguration is detected and reported now.