### PR TITLE
use prop-types instead of React.PropTypes

### DIFF
--- a/lib/Ardagryd.js
+++ b/lib/Ardagryd.js
@@ -1,5 +1,5 @@
-import React, { PropTypes } from 'react';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import GridTable from './GridTable';
 import GridBody from './GridBody';
 import GridColumnHeader from './GridColumnHeader';

--- a/lib/ArrayCellRenderer.js
+++ b/lib/ArrayCellRenderer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { columnsConfig as columnsConfigPropType, globalConfig as globalConfigPropType } from './proptypes';
 
 class ArrayCellRenderer extends Component {

--- a/lib/BaseCellRenderer.js
+++ b/lib/BaseCellRenderer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { columnsConfig as columnsConfigPropType, globalConfig as globalConfigPropType } from './proptypes';
 
 const BaseCellRenderer = (props) =>{

--- a/lib/Column.js
+++ b/lib/Column.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Column extends Component {
     constructor(props){

--- a/lib/Filter.js
+++ b/lib/Filter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import FormControl from 'react-bootstrap/lib/FormControl';
 
 class Filter extends Component {

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Ardagryd from './Ardagryd';
 import { filterConfigFromProp, sortConfigFromProp } from './utils';
 import { sortConfig as sortConfigPropType, filterConfig as filterConfigPropType, globalConfig as globalConfigPropType } from './proptypes';

--- a/lib/GridBody.js
+++ b/lib/GridBody.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import GridRow from './GridRow';
 import { columnsConfig as columnsConfigPropType, globalConfig as globalConfigPropType } from './proptypes';
 

--- a/lib/GridCell.js
+++ b/lib/GridCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const GridCell = (props) => {
     const {component: Component, ...rest } = props;

--- a/lib/GridColumnHeader.js
+++ b/lib/GridColumnHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { columnsConfig as columnsConfigPropType, sortConfigSingle as sortConfigSinglePropType, globalConfig as globalConfigPropType } from './proptypes';
 
 const getLabel = (columnKey, columnConfig)=>{

--- a/lib/GridHeader.js
+++ b/lib/GridHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const GridHeader = (props) => <thead>{props.children}</thead>;
 

--- a/lib/GridHeaderCell.js
+++ b/lib/GridHeaderCell.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { ASCENDING, DESCENDING } from './constants';
 import Button from 'react-bootstrap/lib/Button';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';

--- a/lib/GridRow.js
+++ b/lib/GridRow.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import GridCell from './GridCell';
 import { columnsConfig as columnsConfigPropType, globalConfig as globalConfigPropType } from './proptypes';
 

--- a/lib/GridTable.js
+++ b/lib/GridTable.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Table from 'react-bootstrap/lib/Table';
 
 const GridTable = (props) => <Table bordered hover>{props.children}</Table>;

--- a/lib/ObjectCellRenderer.js
+++ b/lib/ObjectCellRenderer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes }  from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { columnsConfig as columnsConfigPropType, globalConfig as globalConfigPropType } from './proptypes';
 
 const ObjectCellRenderer = (props)=> {

--- a/lib/Pager.js
+++ b/lib/Pager.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Pagination from 'react-bootstrap/lib/Pagination';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 

--- a/lib/ToolbarDefault.js
+++ b/lib/ToolbarDefault.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { columnsConfig as columnsConfigPropType, filterConfigSingle as filterConfigSinglePropType, globalConfig as globalConfigPropType } from './proptypes';
 
 class ToolbarDefault extends Component {

--- a/lib/proptypes.js
+++ b/lib/proptypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { ASCENDING, DESCENDING } from './constants';
 import deprecated from 'react-prop-types/lib/deprecated';
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "eddyson GmbH",
   "license": "MIT",
   "dependencies": {
+    "prop-types": "^15.5.7",
     "react-bootstrap": "0.30.8",
     "react-prop-types": "0.4.0"
   },
@@ -58,7 +59,6 @@
     "jsdom": "9.12.0",
     "mocha": "3.2.0",
     "mocha-jsdom": "1.1.0",
-    "prop-types": "^15.5.6",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jsdom": "9.12.0",
     "mocha": "3.2.0",
     "mocha-jsdom": "1.1.0",
+    "prop-types": "^15.5.6",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,12 @@ module.exports = {
           commonjs2: 'react',
           commonjs: 'react',
           amd: 'react'
+        },
+        'prop-types': {
+          root: 'Proptypes',
+          commonjs2: 'prop-types',
+          commonjs: 'prop-types',
+          amd: 'prop-types'
         }
       }
 


### PR DESCRIPTION
Accessing `React.PropTypes` is deprecated as of React 15.5 and will be removed in 16. `prop-types` is the recommended replacement.